### PR TITLE
feat(config) vod entries list + creation view default config on build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { createReadOnlyRoleIfNotExists } from "./setup/readOnlyRole";
-import { setVODLayout } from "./setup/layouts";
+import { setVODLayout, setLiveChannelLayout } from "./setup/layouts";
 
 export default {
 register({ strapi }) {
@@ -9,5 +9,6 @@ register({ strapi }) {
 async bootstrap({ strapi }) {
   createReadOnlyRoleIfNotExists(strapi);
   setVODLayout(strapi);
+  setLiveChannelLayout(strapi);
 },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,118 +1,15 @@
-const readOnlyPermissions = [
-  {
-    action: 'plugin::content-manager.explorer.read',
-    subject: 'plugin::users-permissions.user',
-    conditions: [],
-    properties: {
-      fields: [
-        'username',
-        'email',
-        'provider',
-        'password',
-        'resetPasswordToken',
-        'confirmationToken',
-        'confirmed',
-        'blocked',
-        'role',
-      ],
-    },
-  },
-  {
-    action: 'plugin::content-manager.explorer.read',
-    subject: 'api::category.category',
-    conditions: [],
-    properties: {
-      fields: ['Name', 'genre'],
-    },
-  },
-  {
-    action: 'plugin::content-manager.explorer.read',
-    subject: 'api::genre.genre',
-    conditions: [],
-    properties: {
-      fields: ['Name', 'categories'],
-    },
-  },
-  {
-    action: 'plugin::content-manager.explorer.read',
-    subject: 'api::live-channel.live-channel',
-    conditions: [],
-    properties: {
-      fields: [
-        'name',
-        'input_type',
-        'output_type',
-        'thumbnail',
-        'Live_to_vod',
-        'catch_up',
-        'genre',
-        'category',
-        'genre-category-relation',
-        'vods',
-      ],
-    },
-  },
-  {
-    action: 'plugin::content-manager.explorer.read',
-    subject: 'api::vod.vod',
-    conditions: [],
-    properties: {
-      fields: [
-        'Name',
-        'Thumbnails',
-        'rotation_start',
-        'rotation_end',
-        'description',
-        'live_channel',
-        'genre-category-relation',
-        'views',
-        'genre',
-        'category',
-        'media_url',
-        'highlighted',
-      ],
-    },
-  },
-]
+import { createReadOnlyRoleIfNotExists } from "./setup/readOnlyRole";
+import { setVODLayout } from "./setup/VOD";
 
-const createReadOnlyRole = async () => {
-  const roleService = strapi.services["admin::role"];
-  const data = await strapi.entityService.create('admin::role', {
-    data: {
-      name: 'Read-Only',
-      code: `read-only`,
-      description: 'Read only access for demo user',
-    },
-  });
-  await roleService.assignPermissions(data.id, readOnlyPermissions);
-}
-
-const createReadOnlyRoleIfNotExists = async () => {
-  const data: any[] = await strapi.entityService.findMany("admin::role", {
-    filters: { code: {$eq: "read-only"}}
-  })
-  if (data.length == 0)
-    await createReadOnlyRole();
-};
 
 
 export default {
-/**
- * An asynchronous register function that runs before
- * your application is initialized.
- *
- * This gives you an opportunity to extend code.
- */
-register(/*{ strapi }*/) {},
+register({ strapi }) {
 
-/**
- * An asynchronous bootstrap function that runs before
- * your application gets started.
- *
- * This gives you an opportunity to set up your data model,
- * run jobs, or perform some special logic.
- */
+},
+
 async bootstrap({ strapi }) {
-  createReadOnlyRoleIfNotExists();
+  createReadOnlyRoleIfNotExists(strapi);
+  setVODLayout(strapi);
 },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { createReadOnlyRoleIfNotExists } from "./setup/readOnlyRole";
-import { setVODLayout } from "./setup/VOD";
-
-
+import { setVODLayout } from "./setup/layouts";
 
 export default {
 register({ strapi }) {

--- a/src/setup/VOD.ts
+++ b/src/setup/VOD.ts
@@ -1,9 +1,0 @@
-import VODLayout from "./layouts/VOD.json"
-
-export const setVODLayout = (strapi) => {
-    const contentTypeService = strapi.services["plugin::content-manager.content-types"];
-    const contentType = contentTypeService.findContentType("api::vod.vod");
-    const defaultConfig = contentTypeService.findConfiguration(contentType);
-    contentTypeService.updateConfiguration(contentType, {...defaultConfig, layouts: VODLayout.layouts});
-}
-

--- a/src/setup/VOD.ts
+++ b/src/setup/VOD.ts
@@ -1,0 +1,9 @@
+import VODLayout from "./layouts/VOD.json"
+
+export const setVODLayout = (strapi) => {
+    const contentTypeService = strapi.services["plugin::content-manager.content-types"];
+    const contentType = contentTypeService.findContentType("api::vod.vod");
+    const defaultConfig = contentTypeService.findConfiguration(contentType);
+    contentTypeService.updateConfiguration(contentType, {...defaultConfig, layouts: VODLayout.layouts});
+}
+

--- a/src/setup/layouts.ts
+++ b/src/setup/layouts.ts
@@ -1,0 +1,19 @@
+import VODLayout from "./layouts/VOD.json"
+import LiveChannelLayout from "./layouts/LiveChannel.json"
+
+export const setVODLayout = (strapi) => {
+    const contentTypeService = strapi.services["plugin::content-manager.content-types"];
+    const contentType = contentTypeService.findContentType("api::vod.vod");
+    const defaultConfig = contentTypeService.findConfiguration(contentType);
+    contentTypeService.updateConfiguration(contentType, {...defaultConfig, layouts: VODLayout.layouts});
+}
+
+export const setLiveChannelLayout = (strapi) => {
+    const contentTypeService = strapi.services["plugin::content-manager.content-types"];
+    const contentType = contentTypeService.findContentType("api::live-channel.live-channel");
+    const defaultConfig = contentTypeService.findConfiguration(contentType);
+    contentTypeService.updateConfiguration(contentType, {...defaultConfig, layouts: LiveChannelLayout.layouts});
+}
+
+
+

--- a/src/setup/layouts/LiveChannel.json
+++ b/src/setup/layouts/LiveChannel.json
@@ -1,0 +1,52 @@
+{
+    "layouts": {
+        "edit": [
+        [
+            {
+            "name": "name",
+            "size": 6
+            },
+            {
+            "name": "thumbnail",
+            "size": 6
+            }
+        ],
+        [
+            {
+            "name": "input_type",
+            "size": 6
+            },
+            {
+            "name": "output_type",
+            "size": 6
+            }
+        ],
+        [
+            {
+            "name": "vods",
+            "size": 6
+            },
+            {
+            "name": "genre-category-relation",
+            "size": 6
+            }
+        ],
+        [
+            {
+            "name": "catch_up",
+            "size": 6
+            },
+            {
+            "name": "Live_to_vod",
+            "size": 6
+            }
+        ]
+        ],
+        "list": [
+        "thumbnail",
+        "name",
+        "genre",
+        "category"
+        ]
+    }
+}  

--- a/src/setup/layouts/VOD.json
+++ b/src/setup/layouts/VOD.json
@@ -1,0 +1,60 @@
+{
+  "layouts": {
+    "edit": [
+      [
+        {
+          "name": "Name",
+          "size": 6
+        },
+        {
+          "name": "Thumbnails",
+          "size": 6
+        }
+      ],
+      [
+        {
+          "name": "description",
+          "size": 6
+        },
+        {
+          "name": "genre-category-relation",
+          "size": 6
+        }
+      ],
+      [
+        {
+          "name": "media_url",
+          "size": 12
+        }
+      ],
+      [
+        {
+          "name": "rotation_start",
+          "size": 6
+        },
+        {
+          "name": "rotation_end",
+          "size": 6
+        }
+      ],
+      [
+        {
+          "name": "live_channel",
+          "size": 6
+        },
+        {
+          "name": "highlighted",
+          "size": 6
+        }
+      ]
+    ],
+    "list": [
+      "Thumbnails",
+      "Name",
+      "media_url",
+      "genre",
+      "category",
+      "views"
+    ]
+  }
+}

--- a/src/setup/readOnlyRole.ts
+++ b/src/setup/readOnlyRole.ts
@@ -1,0 +1,63 @@
+const readOnlyUsersPermissions = {
+  action: 'plugin::content-manager.explorer.read',
+  subject: 'plugin::users-permissions.user',
+  conditions: [],
+  properties: {
+    fields: [
+      'username',
+      'email',
+      'provider',
+      'password',
+      'resetPasswordToken',
+      'confirmationToken',
+      'confirmed',
+      'blocked',
+      'role',
+    ],
+  },
+}
+
+const getApiContentTypesFields = (contentTypeService) => {
+  const apiUIDs : string[] = contentTypeService.findAllContentTypes()
+  .map(ct => ct.uid)
+  .filter(uid => uid.startsWith("api::"));
+  const permissions = apiUIDs.map((uid) => {
+    const contentType = contentTypeService.findContentType(uid);
+    const fields = Object.keys(contentType.attributes).filter(key => key !== "id");
+    return {
+      action: 'plugin::content-manager.explorer.read',
+      subject: uid,
+      conditions: [],
+      properties: {
+        fields,
+      },
+    }
+  });
+  return permissions
+};
+
+
+const createReadOnlyRole = async (strapi) => {
+  const contentTypeService = strapi.services["plugin::content-manager.content-types"];
+  const roleService = strapi.services["admin::role"];
+  const permissions = [
+    readOnlyUsersPermissions,
+    ...getApiContentTypesFields(contentTypeService),
+  ];
+  const data = await strapi.entityService.create('admin::role', {
+    data: {
+      name: 'Read-Only',
+      code: `read-only`,
+      description: 'Read only access for demo user',
+    },
+  });
+  await roleService.assignPermissions(data.id, permissions);
+}
+
+export const createReadOnlyRoleIfNotExists = async (strapi) => {
+  const data: any[] = await strapi.entityService.findMany("admin::role", {
+    filters: { code: {$eq: "read-only"}}
+  })
+  if (data.length == 0)
+    await createReadOnlyRole(strapi);
+};


### PR DESCRIPTION
PR related to the task [Entries list configuration as a package](https://trackitcloud.monday.com/boards/4876546328/pulses/5701683917)

Context:
View configuration (displayed fields, labels, page sage) of the entries list (list of VOD, list of Live Channel) are stored in the DB and are lost on new projet building.
So we need to store the default config and set it on first project building using the boostrap() function.

Definition of done:

Each content-types listing should have a default configuration that shows each valuable fields (names, Thumbnails, genre/category, media URL)
User should be able to see them properly from the first building
User should'nt be able to see and modify private fields handled by the API (Owner, Genre as a string, Category as a string)